### PR TITLE
Add training debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,13 @@ Run the tests locally:
 pre-commit run --all-files
 pytest
 ```
+
+## Troubleshooting
+
+- Setting up your simulation: try using debug mode with random actions. This will run your simulation for one episode
+  and output the observations and actions at each step.
+  `simulation.run()`
+
+- Uploading your simulation for training: If you're having issues uploading the simulation for training, you can enable
+  debug-mode: `simulation.train(debug_mode=True)` . This will print the output from uploading and preserve the uploaded file
+  as `training.zip` for you to inspect.

--- a/pathmind/simulation.py
+++ b/pathmind/simulation.py
@@ -171,6 +171,9 @@ class Simulation:
 
             print(f"--------Finished episode {episode}--------")
 
+        write_table(table=table, out_csv=out_csv)
+        write_table(table=summary, out_csv=summary_csv)
+
     def train(
         self,
         base_folder: str = "./",

--- a/pathmind/simulation.py
+++ b/pathmind/simulation.py
@@ -173,11 +173,17 @@ class Simulation:
             write_table(table=summary, out_csv=summary_csv)
             print(f"--------Finished episode {episode}--------")
 
-    def train(self, base_folder: str = "./", observation_yaml: str = None):
+    def train(
+        self,
+        base_folder: str = "./",
+        observation_yaml: str = None,
+        debug_mode: Optional[bool] = False,
+    ) -> None:
         """
         :param base_folder the path to your base folder containing all your Python code. Defaults to the current
             working directory, which assumes you start training from the base of your code base.
         :param observation_yaml: optional string with path to an observation yaml
+        :param debug_mode: optional boolean to save the uploaded training.zip and show the result of uploading.
         """
 
         env_name = str(self.__class__).split("'")[1]
@@ -219,7 +225,14 @@ class Simulation:
                 location = line.split(b": ")[-1]
                 print(f">>> See your Pathmind experiment at: \n\t{location.decode()}")
 
-        return result
+        if debug_mode:
+            print(">>> Result:")
+            print(result)
+        else:
+            zip_file = os.path.join(base_folder, "training.zip")
+            os.remove(zip_file)
+
+        return
 
 
 def write_observation_yaml(simulation: Simulation, folder) -> None:

--- a/tests/test_train_simulation.py
+++ b/tests/test_train_simulation.py
@@ -28,3 +28,9 @@ def test_from_or_gym():
     env = or_gym.make("Knapsack-v0")
     sim = from_gym(env)
     sim.train()
+
+
+def test_training_debug_mode():
+    # TODO check that training.zip exists
+    simulation = MouseAndCheese()
+    simulation.train(debug_mode=True)


### PR DESCRIPTION
- Clean up the default output from `.train()`
- Add Troubleshooting guide to the readme
- Delete the training.zip file unless in debug_mode

Before

![image](https://user-images.githubusercontent.com/1197406/140641323-6c842037-4e3d-48e4-9e1f-53f4d31442fd.png)


After

<img width="503" alt="Screen Shot 2021-11-07 at 2 29 17 AM" src="https://user-images.githubusercontent.com/1197406/140641311-8ef53607-b436-4de6-b807-a6f7dce3a87f.png">

Resolves #30, Fixes #39 